### PR TITLE
登壇者情報を追加

### DIFF
--- a/src/browser/dashboard/data/timeTable.ts
+++ b/src/browser/dashboard/data/timeTable.ts
@@ -1,16 +1,456 @@
-import { type TimeTable } from "../../schema/TimeTable";
+import type { TimeTable } from "../../schema/TimeTable";
 
 export const timeTable = {
   trackOne: [
     {
-      speakerName: "foobar",
-      title: "hogefuga",
+      title: "Keynote",
+      speakerName: "Daniel Rosenwasser",
+      social: {
+        github: "DanielRosenwasser",
+        link: "https://bsky.app/profile/danr.bsky.social",
+        twitter: "drosenwasser",
+      },
     },
     {
-      speakerName: "fooooo",
-      title: "aaaaa",
+      title:
+        "フロントエンドもバックエンドもインフラも… 全てをTypeScriptで統一したらこうなった！",
+      speakerName: "君田 祥一",
+      social: {
+        github: "kimitashoichi",
+        link: "https://kimitashoichi.github.io/Profile",
+        twitter: "kimi_koma1111",
+      },
+    },
+    {
+      title: "TypeScript化の旅: Helpfeelが辿った試行錯誤と成功の道のり",
+      speakerName: "寺本大輝",
+      social: {
+        github: "teramotodaiki",
+        link: "",
+        twitter: "teramotodaiki",
+      },
+    },
+    {
+      title: "PMF達成の立役者！Full TypeScript Architecture の選定背景と構成",
+      speakerName: "丹羽 健",
+      social: {
+        github: "",
+        link: "https://product.career.ascendlogi.co.jp/",
+        twitter: "niwa_takeru",
+      },
+    },
+    {
+      title: "TypeScript 関数型バックエンド開発のリアル",
+      speakerName: "伊藤直也",
+      social: {
+        github: "naoya",
+        link: "",
+        twitter: "naoya_ito",
+      },
+    },
+    {
+      title:
+        "TypeScript の抽象構文木を用いた、数百を超える API の大規模リファクタリング戦略",
+      speakerName: "白栁 広樹",
+      social: {
+        github: "yanaemon",
+        link: "",
+        twitter: "yanaemon169",
+      },
+    },
+    {
+      title: "Step by Stepで学ぶ、ADT(代数的データ型)、モナドからEffect-TSまで",
+      speakerName: "竹下義晃(takezoux2)",
+      social: {
+        github: "takezoux2",
+        link: "",
+        twitter: "takezoux2",
+      },
+    },
+    {
+      title: "ハードウェアを動かすTypeScrptの世界",
+      speakerName: "9wick",
+      social: {
+        github: "9wick",
+        link: "https://9wick.com/",
+        twitter: "9wick",
+      },
+    },
+    {
+      title: "TypeScriptとGraphQLで実現する型安全なAPI実装",
+      speakerName: "Kazuhito Hokamura",
+      social: {
+        github: "hokaccha",
+        link: "",
+        twitter: "hokaccha",
+      },
+    },
+    {
+      title: "Prettierの未来を考える",
+      speakerName: "Sosuke Suzuki",
+      social: {
+        github: "sosukesuzuki",
+        link: "https://sosukesuzuki.dev",
+        twitter: "__sosukeSuzuki",
+      },
+    },
+    {
+      title: "TypeScriptが学生のエンジニアコミュニティ参加を促進する",
+      speakerName: "NoritakaIkeda",
+      social: {
+        github: "NoritakaIkeda",
+        link: "",
+        twitter: "omotidaisukijp",
+      },
+    },
+    {
+      title: "Reactでハードウェア制御できるEdison.jsを作っている",
+      speakerName: "Allen Shintani",
+      social: {
+        github: "AllenShintani",
+        link: "https://edison-js-document.vercel.app/",
+        twitter: "allenganbaru",
+      },
+    },
+    {
+      title:
+        "多言語化対応における TypeScript の型定義を通して開発のしやすさについて考えた",
+      speakerName: "nabeliwo",
+      social: {
+        github: "nabeliwo",
+        link: "https://blog.nabeliwo.com",
+        twitter: "nabeliwo",
+      },
     },
   ],
-  trackTwo: [],
-  trackThree: [],
+  trackTwo: [
+    {
+      title: "TypeScript ASTを利用したコードジェネレーターの実装入門",
+      speakerName: "Himenon",
+      social: {
+        github: "Himenon",
+        link: "https://himenon.github.io/",
+        twitter: "Himenoglyph",
+      },
+    },
+    {
+      title: "TypescriptでのContextualな構造化ロギングと社内全体への導入！",
+      speakerName: "瀬尾 光希",
+      social: {
+        github: "",
+        link: "https://my.prairie.cards/u/seoink",
+        twitter: "_seoink",
+      },
+    },
+    {
+      title: "Typescriptで使いやすいOpenAPIの書き方",
+      speakerName: "上坂 直輝",
+      social: {
+        github: "yukimochi",
+        link: "",
+        twitter: "",
+      },
+    },
+    {
+      title: "生成 AI と Cloud Workstations で始めるクラウド AI ネイティブ開発",
+      speakerName: "Hiroyuki Momoi",
+      social: {
+        github: "m0m0i",
+        link: "",
+        twitter: "",
+      },
+    },
+    {
+      title: "EARTHBRAINが挑むグローバルな課題とTypeScriptの活用事例について",
+      speakerName: "yasaichi",
+      social: {
+        github: "yasaichi",
+        link: "https://earthbrain.notion.site/EARTHBRAIN-Tech-3775fb71b41342aebf0aee6848d722bd",
+        twitter: "_yasaichi",
+      },
+    },
+    {
+      title: "TypeScriptで統一したアーキテクチャ",
+      speakerName: "井関正也",
+      social: {
+        github: "iseki-masaya",
+        link: "https://even-eko.hatenablog.com/",
+        twitter: "iskmsy",
+      },
+    },
+    {
+      title: "TypeScriptと型のパフォーマンス",
+      speakerName: "ypresto",
+      social: {
+        github: "ypresto",
+        link: "",
+        twitter: "yuya_presto",
+      },
+    },
+    {
+      title: "TypeScriptから始めるVR生活",
+      speakerName: "TamaG",
+      social: {
+        github: "TAMAGOKAKEG",
+        link: "",
+        twitter: "TAMAGOKAKE_G_",
+      },
+    },
+    {
+      title: "TypeScript をパワフルに使って開発したい！",
+      speakerName: "ユーン",
+      social: {
+        github: "euxn23",
+        link: "https://blog.euxn.me",
+        twitter: "euxn23",
+      },
+    },
+    {
+      title: "TypeScriptでもLLMアプリケーション開発！LangChain.js入門",
+      speakerName: "r-kagaya",
+      social: {
+        github: "",
+        link: "",
+        twitter: "ry0_kaga",
+      },
+    },
+    {
+      title: "TanStack Routerで型安全かつ効率的なルーティングを実現",
+      speakerName: "安井大晟（ytaisei）",
+      social: {
+        github: "taisei-13046",
+        link: "",
+        twitter: "ytaisei_",
+      },
+    },
+    {
+      title: "tRPCを実務に導入して分かった旨味と苦味",
+      speakerName: "海老原 圭吾",
+      social: {
+        github: "misoton665",
+        link: "",
+        twitter: "misoton665",
+      },
+    },
+    {
+      title: "サービス開発におけるVue3とTypeScriptの親和性について",
+      speakerName: "からころ",
+      social: {
+        github: "tsukuha",
+        link: "https://zenn.dev/karan_coron",
+        twitter: "karan_corons",
+      },
+    },
+    {
+      title: "Exploring type-informed lint rules in Rust based Linters",
+      speakerName: "unvalley",
+      social: {
+        github: "unvalley",
+        link: "http://unvalley.me",
+        twitter: "unvalley_",
+      },
+    },
+    {
+      title: "TypeScriptのパフォーマンス改善",
+      speakerName: "やじはむ",
+      social: {
+        github: "yajihum",
+        link: "https://blog.yajihum.dev/",
+        twitter: "yajihum",
+      },
+    },
+    {
+      title: "ts-morphを使ってコードリプレイスとASTへのハードルを下げる！",
+      speakerName: "姫野 佑介",
+      social: {
+        github: "nyawach",
+        link: "https://hyme.site/",
+        twitter: "_hyme_",
+      },
+    },
+    {
+      title: "SWC Transformerから見るTypeScript関数記述ベストプラクティス",
+      speakerName: "Kaito Fujimura",
+      social: {
+        github: "fujiyamaorange",
+        link: "https://fujiyamaorange.vercel.app/",
+        twitter: "fujiyamaorange",
+      },
+    },
+    {
+      title: "TypeScriptのコード生成をつらくしないために",
+      speakerName: "ノーン（nkowne63）",
+      social: {
+        github: "nkowne63",
+        link: "",
+        twitter: "nkowne63",
+      },
+    },
+    {
+      title: "Documetation testsの恩恵",
+      speakerName: "ssssota",
+      social: {
+        github: "ssssota",
+        link: "",
+        twitter: "ssssotaro",
+      },
+    },
+    {
+      title: "Full TypeScriptだから実現できる世界線",
+      speakerName: "k-ichirof",
+      social: {
+        github: "k1rof18",
+        link: "",
+        twitter: "k1rof18",
+      },
+    },
+    {
+      title: "Real World Type Puzzle and Code Generation",
+      speakerName: "Yuku Kotani",
+      social: {
+        github: "yukukotani",
+        link: "https://yuku.dev",
+        twitter: "yukukotani",
+      },
+    },
+  ],
+  trackThree: [
+    {
+      title: "Prisma ORMを2年運用して培ったノウハウを共有する",
+      speakerName: "tockn (Takuto Sato)",
+      social: {
+        github: "tockn",
+        link: "",
+        twitter: "tockn_s",
+      },
+    },
+    {
+      title: "toggle holdingsとTSあるいはTSKaigi",
+      speakerName: "Tatsuro Hisamori",
+      social: {
+        github: "myfinder",
+        link: "",
+        twitter: "myfinder",
+      },
+    },
+    {
+      title: "高まった熱量をぶつけられるコミュニティ活動のススメ",
+      speakerName: "河又 涼",
+      social: {
+        github: "",
+        link: "",
+        twitter: "r_kawamata",
+      },
+    },
+    {
+      title: "こんなTypescriptは嫌だ",
+      speakerName: "佐藤 拓人",
+      social: {
+        github: "taku7777777",
+        link: "https://qiita.com/takuuuuuuu777",
+        twitter: "takuuuuuuu777",
+      },
+    },
+    {
+      title: "チームで挑むTypeScriptコードの漸進的改善",
+      speakerName: "髙橋 佑太",
+      social: {
+        github: "YTakahashii",
+        link: "",
+        twitter: "Wakeupsloth",
+      },
+    },
+    {
+      title: "Ubie のプロダクト開発における技術的レバレッジポイント3選",
+      speakerName: "yoheikikuta",
+      social: {
+        github: "yoheikikuta",
+        link: "https://yoheikikuta.github.io/",
+        twitter: "yohei_kikuta",
+      },
+    },
+    {
+      title: "部分型の代数的模型",
+      speakerName: "PADAone",
+      social: {
+        github: "yo-goto",
+        link: "https://publish.obsidian.md/pd1-notes/start-page",
+        twitter: "pd1xx",
+      },
+    },
+    {
+      title:
+        "複雑なビジネスルールに挑む：正確性と効率性を両立するfp-tsのチーム活用術",
+      speakerName: "kosui",
+      social: {
+        github: "iwasa-kosui",
+        link: "https://www.kosui.me/",
+        twitter: "kosui_me",
+      },
+    },
+    {
+      title: "Type-safety in Angular",
+      speakerName: "lacolaco",
+      social: {
+        github: "lacolaco",
+        link: "https://lacolaco.net",
+        twitter: "laco2net",
+      },
+    },
+    {
+      title: "TypeScriptできると思ったのは勘違いだった件",
+      speakerName: "Daishi Kato (加藤大志)",
+      social: {
+        github: "dai-shi",
+        link: "https://daishikato.com",
+        twitter: "dai_shi",
+      },
+    },
+    {
+      title: "Effectで作る堅牢でスケーラブルなAPIゲートウェイ",
+      speakerName: "yasaichi",
+      social: {
+        github: "yasaichi",
+        link: "",
+        twitter: "_yasaichi",
+      },
+    },
+    {
+      title:
+        "Introduction to Database Connection Management Patterns in TypeScript！LangChain.js入門",
+      speakerName: "Sugar",
+      social: {
+        github: "sugar-cat7",
+        link: "https://sugar-cat7.github.io/portfolio",
+        twitter: "sugar235711",
+      },
+    },
+    {
+      title: "Prismaでスキーマ変更を行う際のベストプラクティス",
+      speakerName: "ryusaka",
+      social: {
+        github: "ryusaka",
+        link: "",
+        twitter: "",
+      },
+    },
+    {
+      title: "Denoで作る快適な “as Code” プラットフォーム",
+      speakerName: "pizzacat83",
+      social: {
+        github: "pizzacat83",
+        link: "https://pizzacat83.com/",
+        twitter: "pizzacat83b",
+      },
+    },
+    {
+      title: "ｽﾀｯｸﾁｬﾝ -TypeScriptで動くオープンソースロボット-",
+      speakerName: "ししかわ",
+      social: {
+        github: "meganetaaan",
+        link: "https://meganetaaan.jp/",
+        twitter: "stack_chan",
+      },
+    },
+  ],
 } as const satisfies TimeTable;

--- a/src/browser/graphics/views/talk.tsx
+++ b/src/browser/graphics/views/talk.tsx
@@ -58,6 +58,11 @@ const App: FC = () => {
   const talk = getCurrentTalk(timeTable, progress, {
     speakerName: "",
     title: "",
+    social: {
+      github: "",
+      link: "",
+      twitter: "",
+    },
   });
 
   return (
@@ -75,11 +80,7 @@ const App: FC = () => {
           <TalkDescription
             title={talk.title}
             name={talk.speakerName}
-            social={{
-              github: "ken7253",
-              link: "example.com",
-              twitter: "ken7253",
-            }}
+            social={talk.social}
           />
         </div>
       </div>

--- a/src/browser/schema/TimeTable.ts
+++ b/src/browser/schema/TimeTable.ts
@@ -3,6 +3,11 @@ import { object, string, array, type Output } from "valibot";
 export const TrackItemSchema = object({
   speakerName: string(),
   title: string(),
+  social: object({
+    github: string(),
+    link: string(),
+    twitter: string(),
+  }),
 });
 
 export const TimeTableSchema = object({


### PR DESCRIPTION
closes #9
ref https://github.com/tskaigi/tskaigi2024/issues/196

## やったこと
- issueの参考情報 https://github.com/tskaigi/tskaigi.github.io/pull/109 から登壇者情報を取得するスクリプト https://github.com/tskaigi/tskaigi-layout/commit/dc098b6e7c1e05f46f57ffd7b689bce0c54ac5aa を作成して登壇者情報を追加
- アカウント情報も登録
- https://github.com/tskaigi/tskaigi-layout/commit/dc098b6e7c1e05f46f57ffd7b689bce0c54ac5aa は書き捨てのスクリプト&サブモジュールも追加してるので別ブランチにpushしました
- speakerNameは、https://github.com/tskaigi/tskaigi.github.io/blob/feature/sesseion_detail/constants/index.ts#L67 のdisplayNameと対応しています