### PR TITLE
fix: 未設定のソーシャルリンクをフィルタリングするよう修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /extension
 
 # editor
-
+.idea
 .vscode/settings.json
 
 # Logs

--- a/src/browser/graphics/components/TalkDescription/index.tsx
+++ b/src/browser/graphics/components/TalkDescription/index.tsx
@@ -38,7 +38,7 @@ export const TalkDescription: FC<Props> = ({
   social,
   areaName = "",
 }) => {
-  const socials = Object.entries(social ?? {}).filter(([,v]) => v !== "");
+  const socials = Object.entries(social ?? {}).filter(([, v]) => v !== "");
 
   return (
     <div style={{ gridArea: areaName }} className={styles.container}>

--- a/src/browser/graphics/components/TalkDescription/index.tsx
+++ b/src/browser/graphics/components/TalkDescription/index.tsx
@@ -38,7 +38,7 @@ export const TalkDescription: FC<Props> = ({
   social,
   areaName = "",
 }) => {
-  const socials = Object.entries(social ?? {});
+  const socials = Object.entries(social ?? {}).filter(([,v]) => v !== "");
 
   return (
     <div style={{ gridArea: areaName }} className={styles.container}>


### PR DESCRIPTION
#32 の修正です

### 修正前
![スクリーンショット 2025-05-05 20 14 07](https://github.com/user-attachments/assets/1c0c7048-7d22-4a21-9c35-cdefe0b0a033)

### 修正後
![スクリーンショット 2025-05-05 20 19 46](https://github.com/user-attachments/assets/6523afe6-dad6-49c5-8a74-2cea923ed122)

