### PR TITLE
ソーシャル情報が増殖する不具合の解消

### DIFF
--- a/src/browser/graphics/components/TalkDescription/index.tsx
+++ b/src/browser/graphics/components/TalkDescription/index.tsx
@@ -52,7 +52,7 @@ export const TalkDescription: FC<Props> = ({
           </p>
           <ul className={styles.socialList}>
             {socials.map(([key, v]) => (
-              <li className={styles.socialItem} key={v}>
+              <li className={styles.socialItem} key={key}>
                 {match(key)
                   .with(P.union("link", "github", "twitter"), (p) => iconMap[p])
                   .otherwise(() => null)}


### PR DESCRIPTION
Reactの差分検出で利用されるKey属性がvalueになっており、削除されなかったためkeyで判定するように変更