### PR TITLE
Chore/docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  nodecg:
+    image: ghcr.io/nodecg/nodecg:latest
+    volumes:
+      - "assets:/opt/nodecg/assets:rw"
+      - "db:/opt/nodecg/db:rw"
+      - "./cfg:/opt/nodecg/cfg:rw"
+      - "./dashboard:/opt/nodecg/bundles/tskaigi-layout/dashboard:ro"
+      - "./graphics:/opt/nodecg/bundles/tskaigi-layout/graphics:ro"
+      - "./extension:/opt/nodecg/bundles/tskaigi-layout/extension:ro"
+      - "./node_modules:/opt/nodecg/bundles/tskaigi-layout/node_modules:ro"
+      - "./package.json:/opt/nodecg/bundles/tskaigi-layout/package.json:ro"
+    ports:
+      - "9090:9090"
+
+volumes:
+  assets:
+  db:
+  node_modules:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nodecg:
-    image: ghcr.io/nodecg/nodecg:latest
+    image: ghcr.io/nodecg/nodecg:2.3.2
     volumes:
       - "assets:/opt/nodecg/assets:rw"
       - "db:/opt/nodecg/db:rw"

--- a/src/browser/graphics/presentations/talk.tsx
+++ b/src/browser/graphics/presentations/talk.tsx
@@ -30,7 +30,7 @@ export const Presentation: FC<PresentationProps> = ({
   platinumSponsors,
 }) => {
   const dayZero = Temporal.ZonedDateTime.from({
-    year: 2020,
+    year: 2025,
     month: 5,
     day: 22,
     timeZone: "Asia/Tokyo",
@@ -48,7 +48,7 @@ export const Presentation: FC<PresentationProps> = ({
       <MetaInformation
         trackName={trackName}
         day={day}
-        hashtag={["tskaigi20205", roomHashtag]}
+        hashtag={["tskaigi2025", roomHashtag]}
         areaName={gridAreaName.meta}
       />
       <SponsorArea


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yaml` file to streamline the setup of the NodeCG environment and updates event-related metadata in the `Presentation` component to reflect the year 2025. Below is a breakdown of the most important changes:

### Environment setup improvements:
* Added a `docker-compose.yaml` file to define the NodeCG service, including volume mappings for assets, database, configuration, and bundles, as well as port exposure for the NodeCG dashboard. This simplifies the process of running the NodeCG environment.

### Event metadata updates:
* Updated the year in the `dayZero` definition within the `Presentation` component to 2025, aligning with the new event timeline.
* Updated the event hashtag in the `MetaInformation` component to "tskaigi2025" to reflect the updated year.