### PR TITLE
feat: オープニングトークをトラックリストに追加

### DIFF
--- a/src/browser/dashboard/data/timeTable.ts
+++ b/src/browser/dashboard/data/timeTable.ts
@@ -2,6 +2,15 @@ import { TimeTable, TrackItem } from "../../schema/TimeTable";
 
 const toggleTalkDay1List = [
   {
+    speakerName: "",
+    title: "オープニングトーク",
+    social: {
+      github: "",
+      link: "",
+      twitter: "",
+    },
+  },
+  {
     speakerName: "Anthony Fu",
     title: "The New Powerful ESLint Config with Type Safety",
     social: {
@@ -114,6 +123,15 @@ const toggleTalkDay1List = [
 ] as const satisfies TrackItem[];
 
 const toggleTalkDay2List = [
+  {
+    speakerName: "",
+    title: "オープニングトーク",
+    social: {
+      github: "",
+      link: "",
+      twitter: "",
+    },
+  },
   {
     title: "TypeScriptネイティブ移植観察レポート TSKaigi 2025",
     speakerName: "berlysia",


### PR DESCRIPTION
This pull request adds an "オープニングトーク" (Opening Talk) entry to the `toggleTalkDay1List` and `toggleTalkDay2List` in the `timeTable.ts` file. This change introduces a placeholder entry for the opening talk without specifying a speaker or social links.

### Updates to time table data:

* [`src/browser/dashboard/data/timeTable.ts`](diffhunk://#diff-ab6bafe5424de6d60dad6fcf86181b37c35af446e6ee5ada4d7a56ccfa27f0cdR4-R12): Added an "オープニングトーク" entry to the `toggleTalkDay1List` with empty `speakerName` and `social` fields.
* [`src/browser/dashboard/data/timeTable.ts`](diffhunk://#diff-ab6bafe5424de6d60dad6fcf86181b37c35af446e6ee5ada4d7a56ccfa27f0cdR126-R134): Added an "オープニングトーク" entry to the `toggleTalkDay2List` with empty `speakerName` and `social` fields.