### PR TITLE
fix: ルーム変更時に配列外部へのアクセスで管理画面がクラッシュする現象を修正

### DIFF
--- a/src/browser/dashboard/views/Talk.tsx
+++ b/src/browser/dashboard/views/Talk.tsx
@@ -62,9 +62,15 @@ const App: FC = () => {
       return;
     }
 
+    let index = progress.index;
+    // ルーム変更時に、現在のindexが新しいルームの発表数を超えていたら調整する
+    if (index >= timeTable[room].length) {
+      index = timeTable[room].length - 1;
+    }
+
     setProgress({
-      ...progress,
       room,
+      index,
     });
   };
 

--- a/src/browser/dashboard/views/components/TalkSummary/index.tsx
+++ b/src/browser/dashboard/views/components/TalkSummary/index.tsx
@@ -80,8 +80,8 @@ export const TalkSummary: FC<Props> = ({
               {`${talkIndex + 1} / ${timeTable[room].length}`}
             </TalkIndex>
             <Speaker
-              name={timeTable[room][talkIndex].speakerName ?? ""}
-              title={timeTable[room][talkIndex].title ?? ""}
+              name={timeTable[room][talkIndex]?.speakerName ?? ""}
+              title={timeTable[room][talkIndex]?.title ?? ""}
               layout={layout}
               doNotShowFace={timeTable[room][talkIndex]?.doNotShowFace}
               doNotShowFaceNext={timeTable[room][talkIndex + 1]?.doNotShowFace}


### PR DESCRIPTION
Fix #24 

ルームによってトラック数が違う場合、変更時に配列外部へのアクセスが起きてクラッシュする問題があったため修正しました。

## 変更点

- ルーム変更時に index がトラック数を超えていたら、最後のトラックを差すように修正
- TalkSummary の方でも、配列外部へのアクセスで undefined になってもクラッシュしないように念の為修正

## 動作確認

**手順**

1. `cfg/tskaigi-layout.sample.json` を `cfg/tskaigi-layout.json` に変更した上で起動
2. ダッシュボードで trackOne のトラック進行状況を 27 以上に設定
3. trackTwo に変更

- [x] トラック進行状況が 26 になり、管理画面がクラッシュしない